### PR TITLE
ci: update Docker workflow trigger conditions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,9 +2,6 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches:
-      - development
-      - main
     tags:
       - '*'
 


### PR DESCRIPTION
Remove branch-based triggers (development, main) from GitHub workflow, now only triggering on tag pushes